### PR TITLE
Replaced 'destructor' with IDispose in StreamOutlet

### DIFF
--- a/LSL.cs
+++ b/LSL.cs
@@ -304,8 +304,8 @@ public class liblsl
     * A stream outlet.
     * Outlets are used to make streaming data (and the meta-data) available on the lab network.
     */
-    public class StreamOutlet
-    {
+    public class StreamOutlet : IDisposable
+        {
         /**
         * Establish a new stream outlet. This makes the stream discoverable.
         * @param info The stream information to use for creating this stream. Stays constant over the lifetime of the outlet.
@@ -317,10 +317,13 @@ public class liblsl
         public StreamOutlet(StreamInfo info, int chunk_size = 0, int max_buffered = 360) { obj = dll.lsl_create_outlet(info.handle(), chunk_size, max_buffered); }
 
         /**
-        * Destructor.
+        * Dispose.
         * The stream will no longer be discoverable after destruction and all paired inlets will stop delivering data.
         */
-        ~StreamOutlet() { dll.lsl_destroy_outlet(obj); }
+        public void Dispose()
+        {
+            dll.lsl_destroy_outlet(obj);
+        }
 
 
         // ========================================

--- a/LSL.cs
+++ b/LSL.cs
@@ -156,11 +156,26 @@ public class liblsl
         public StreamInfo(string name, string type, int channel_count = 1, double nominal_srate = IRREGULAR_RATE, channel_format_t channel_format = channel_format_t.cf_float32, string source_id = "") { obj = dll.lsl_create_streaminfo(name, type, channel_count, nominal_srate, channel_format, source_id); }
         public StreamInfo(IntPtr handle) { obj = handle; }
 
+        /// Destroy a previously created streaminfo object.
+        ~StreamInfo() { Dispose(false); }
+
         /// Dispose of the object
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        private bool _disposed = false;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
             dll.lsl_destroy_streaminfo(obj);
             obj = IntPtr.Zero;
+            _disposed = true;
         }
       
         // ========================
@@ -320,14 +335,28 @@ public class liblsl
         */
         public StreamOutlet(StreamInfo info, int chunk_size = 0, int max_buffered = 360) { obj = dll.lsl_create_outlet(info.handle(), chunk_size, max_buffered); }
 
+        ~StreamOutlet() { Dispose(false); }
+
         /**
         * Dispose.
-        * The stream will no longer be discoverable after destruction and all paired inlets will stop delivering data.
+        * The stream will no longer be discoverable after disposal (or when disposed by the GC) and all paired inlets will stop delivering data.
         */
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        private bool _disposed = false;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
             dll.lsl_destroy_outlet(obj);
             obj = IntPtr.Zero;
+            _disposed = true;
         }
 
 
@@ -514,14 +543,28 @@ public class liblsl
                 dll.lsl_set_postprocessing(obj, postproc_flags);
             }
 
+        ~StreamInlet() { Dispose(false); }
+
         /** 
-        * Dispose.
-        * The inlet will automatically disconnect if destroyed.
+        * Dispose
+        * The inlet will be disconnect after disposal (or when disposed by the GC)
         */
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        private bool _disposed = false;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
             dll.lsl_destroy_inlet(obj);
             obj = IntPtr.Zero;
+            _disposed = true;
         }
 
         /**
@@ -811,13 +854,25 @@ public class liblsl
         public ContinuousResolver(string pred) { obj = dll.lsl_create_continuous_resolver_bypred(pred, 5.0); }
         public ContinuousResolver(string pred, double forget_after) { obj = dll.lsl_create_continuous_resolver_bypred(pred, forget_after); }
 
-        /** 
-        * Dispose.
-        */
+        ~ContinuousResolver() { Dispose(false); }
+
+        /// Dispose of the object
         public void Dispose()
-        { 
-            dll.lsl_destroy_continuous_resolver(obj);
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        private bool _disposed = false;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+             dll.lsl_destroy_continuous_resolver(obj);
             obj = IntPtr.Zero;
+            _disposed = true;
         }
 
         /**

--- a/LSL.cs
+++ b/LSL.cs
@@ -134,7 +134,7 @@ public class liblsl
     * written to disk when recording the stream (playing a similar role as a file header).
     */
 
-    public class StreamInfo
+    public class StreamInfo: IDisposable
     {
         /**
         * Construct a new StreamInfo object.
@@ -156,9 +156,13 @@ public class liblsl
         public StreamInfo(string name, string type, int channel_count = 1, double nominal_srate = IRREGULAR_RATE, channel_format_t channel_format = channel_format_t.cf_float32, string source_id = "") { obj = dll.lsl_create_streaminfo(name, type, channel_count, nominal_srate, channel_format, source_id); }
         public StreamInfo(IntPtr handle) { obj = handle; }
 
-        /// Destroy a previously created streaminfo object.
-        ~StreamInfo() { dll.lsl_destroy_streaminfo(obj); }
-
+        /// Dispose of the object
+        public void Dispose()
+        {
+            dll.lsl_destroy_streaminfo(obj);
+            obj = IntPtr.Zero;
+        }
+      
         // ========================
         // === Core Information ===
         // ========================
@@ -323,6 +327,7 @@ public class liblsl
         public void Dispose()
         {
             dll.lsl_destroy_outlet(obj);
+            obj = IntPtr.Zero;
         }
 
 
@@ -482,7 +487,7 @@ public class liblsl
     * A stream inlet.
     * Inlets are used to receive streaming data (and meta-data) from the lab network.
     */
-    public class StreamInlet
+    public class StreamInlet: IDisposable
     {
 /**
         * Construct a new stream inlet from a resolved stream info.
@@ -510,10 +515,14 @@ public class liblsl
             }
 
         /** 
-        * Destructor.
+        * Dispose.
         * The inlet will automatically disconnect if destroyed.
         */
-        ~StreamInlet() { dll.lsl_destroy_inlet(obj); }
+        public void Dispose()
+        {
+            dll.lsl_destroy_inlet(obj);
+            obj = IntPtr.Zero;
+        }
 
         /**
         * Retrieve the complete information of the given stream, including the extended description.
@@ -770,7 +779,7 @@ public class liblsl
     * visible on the network.
     */
 
-    public class ContinuousResolver
+    public class ContinuousResolver: IDisposable
     {
         /**
         * Construct a new continuous_resolver that resolves all streams on the network. 
@@ -803,9 +812,13 @@ public class liblsl
         public ContinuousResolver(string pred, double forget_after) { obj = dll.lsl_create_continuous_resolver_bypred(pred, forget_after); }
 
         /** 
-        * Destructor.
+        * Dispose.
         */
-        ~ContinuousResolver() { dll.lsl_destroy_continuous_resolver(obj); }
+        public void Dispose()
+        { 
+            dll.lsl_destroy_continuous_resolver(obj);
+            obj = IntPtr.Zero;
+        }
 
         /**
         * Obtain the set of currently present streams on the network (i.e. resolve result).


### PR DESCRIPTION
Relying on destructor does not work in garbage collection environment. The stream outlet will remain open until garbage collection takes care of it for you.  This is random and non deterministic, so your outlet will remain open long after you want it gone.

Use IDisposable gives you explicit control over the outlet destruction.  You may now wrap the outlet in a using statement to control when it is destroyed.

example

 using (var outlet = new liblsl.StreamOutlet(StreamInfo))
{
}  //  Outlet is always destroyed after this closing bracket goes out of scope, giving you the control you need over when the outlet gets closed.