### PR TITLE
Add support for nuget package generation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <Authors>Christian Kothe</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.12.2</Version>
-  </PropertyGroup>
-</Project>
-

--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -1,6 +1,9 @@
 <Project>
-<Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
+    <Authors>Christian Kothe</Authors>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>1.12.2</Version>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 </Project>
+

--- a/liblsl.csproj
+++ b/liblsl.csproj
@@ -7,6 +7,15 @@
     <Version>2.0</Version>
     <DefaultItemExcludes>$(DefaultItemExcludes);examples/**</DefaultItemExcludes>
     <AssemblyName>lsl_csharp</AssemblyName>
+    <Copyright>Copyright © Christian Kothe 2021</Copyright>
+    <ProjectUrl>https://github.com/labstreaminglayer/liblsl-Csharp</ProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>LSL Lab Streaming Layer</PackageTags>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <RuntimeIdentifiers>win-x86;win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
-</Project>
 
+  <ItemGroup>
+    <Content Include="runtimes\**" Exclude="runtimes\README.md" PackagePath="runtimes" />
+  </ItemGroup>
+</Project>

--- a/runtimes/README.md
+++ b/runtimes/README.md
@@ -1,0 +1,3 @@
+# Runtime Identifier Dependencies
+
+The NuGet package for the C# bindings includes binary distributions for major platform runtimes targeted by [liblsl](https://github.com/sccn/liblsl). To successfully build the package, these binaries need to be downloaded from [liblsl releases](https://github.com/sccn/liblsl/releases) and included in this folder following the RID naming conventions outlined in the [RID Catalog](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog).

--- a/runtimes/README.md
+++ b/runtimes/README.md
@@ -1,3 +1,65 @@
 # Runtime Identifier Dependencies
 
 The NuGet package for the C# bindings includes binary distributions for major platform runtimes targeted by [liblsl](https://github.com/sccn/liblsl). To successfully build the package, these binaries need to be downloaded from [liblsl releases](https://github.com/sccn/liblsl/releases) and included in this folder following the RID naming conventions outlined in the [RID Catalog](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog).
+
+The following [architecture-specific folders](https://docs.microsoft.com/en-us/nuget/create-packages/supporting-multiple-target-frameworks#architecture-specific-folders) are recommended:
+
+```
+\runtimes
+    \linux-x64
+        \native
+            liblsl.so
+            liblsl.so.1.14.0
+    \osx-x64
+        \native
+            liblsl.dylib
+            liblsl.1.14.0.dylib
+    \win-x64
+        \native
+            lsl.dll
+    \win-x86
+        \native
+            lsl.dll
+```
+
+## Project files for dependent projects
+
+From Visual Studio 2019, both .NET Core (`dotnet`) and .NET Framework compilers will use the `RuntimeIdentifier` element of the new SDK csproj format to control which native dependencies to deploy to the final output folder.
+
+### .NET Core
+In .NET Core, the default is to generate cross-platform deployments, which means that all the runtimes will be deployed to the final output folder. By inserting a specific `RuntimeIdentifier` a build targeting only the specified architecture is generated.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <!--<RuntimeIdentifier>linux-x64</RuntimeIdentifier>-->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="lsl_csharp" Version="2.0.0" />
+  </ItemGroup>
+
+</Project>
+```
+
+### .NET Framework
+In legacy .NET framework projects, `RuntimeIdentifier` defaults to `win7-x86` which has the generic fallback to `win-x86`. Therefore, the above folder structure will automatically copy `lsl.dll` into the output folder of .NET Framework projects.
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <!--<RuntimeIdentifier>win-x64</RuntimeIdentifier>-->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="lsl_csharp" Version="2.0.0" />
+  </ItemGroup>
+
+</Project>
+```


### PR DESCRIPTION
Fixes #2

This PR expands support for nuget package generation including common metadata such as projectURL, package license and package tags. A `README.md` file has been included in the runtime identifier folder to explain how to correctly build the package.

At the moment, assemblies in the runtimes folder ~need to be resolved manually by calling `SetLibraryPath` or using the `deps.json` file when publishing a .NET Core app. Nevertheless t~ are resolved automatically by both .NET Core and .NET Framework according to the relevant runtime identifier, as long as the package architecture-specific folders are correctly declared. This package follows the ~foreseeable~ standards for platform-specific native dependencies using runtime identifiers going forward from .NET 5.0 as documented in [RID Catalog](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog) and in the section on [architecture-specific folders](https://docs.microsoft.com/en-us/nuget/create-packages/supporting-multiple-target-frameworks#architecture-specific-folders). 