### PR TITLE
Remove redundant 'internal'

### DIFF
--- a/LSL.cs
+++ b/LSL.cs
@@ -196,7 +196,7 @@ namespace LSL
                     case -1: throw new TimeoutException("The operation failed due to a timeout.");
                     case -2: throw new LostException("The stream has been lost.");
                     case -3: throw new ArgumentException("An argument was incorrectly specified (e.g., wrong format or wrong length).");
-                    case -4: throw new InternalException("An internal internal error has occurred.");
+                    case -4: throw new InternalException("An internal error has occurred.");
                     default: throw new Exception("An unknown error has occurred.");
                 }
         }


### PR DESCRIPTION
This patch removes redundant 'internal' in exception message.